### PR TITLE
refactor(backend): simplify logger configuration

### DIFF
--- a/backend/src/askpolis/celery.py
+++ b/backend/src/askpolis/celery.py
@@ -1,9 +1,7 @@
 import celery_typed_tasks
 from celery import Celery
 
-from askpolis.logging import configure_logging, get_logger
-
-configure_logging()
+from askpolis.logging import get_logger
 
 logger = get_logger(__name__)
 logger.info("Starting Celery worker...")

--- a/backend/src/askpolis/logging.py
+++ b/backend/src/askpolis/logging.py
@@ -3,6 +3,8 @@ import os
 from logging import Logger
 from typing import Any, cast
 
+_configured = False
+
 
 class AttributesAwareLogger(Logger):
     def debug_with_attrs(self: Logger, message: str, attrs: dict[str, Any]) -> None:
@@ -18,11 +20,15 @@ class AttributesAwareLogger(Logger):
         return self.error(_expand_message(message, attrs))
 
 
-def configure_logging() -> None:
-    logging.setLoggerClass(AttributesAwareLogger)
+def _configure_logging() -> None:
+    global _configured
+    if not _configured:
+        logging.setLoggerClass(AttributesAwareLogger)
+        _configured = True
 
 
 def get_logger(name: str) -> AttributesAwareLogger:
+    _configure_logging()
     logger = cast(AttributesAwareLogger, logging.getLogger(name))
     logger.setLevel(_get_log_level_from_otel_default_env_var())
     return logger

--- a/backend/src/askpolis/main.py
+++ b/backend/src/askpolis/main.py
@@ -7,11 +7,9 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
 from askpolis.core import Parliament, ParliamentRepository, get_parliament_repository
-from askpolis.logging import configure_logging, get_logger
+from askpolis.logging import get_logger
 from askpolis.qa import router as qa_router
 from askpolis.search import router as search_router
-
-configure_logging()
 
 logger = get_logger(__name__)
 logger.info("Starting AskPolis API...")

--- a/backend/src/askpolis/search/embeddings_service.py
+++ b/backend/src/askpolis/search/embeddings_service.py
@@ -8,13 +8,11 @@ from FlagEmbedding import BGEM3FlagModel
 from FlagEmbedding.inference.embedder.encoder_only.m3 import M3Embedder
 
 from askpolis.core import Document, MarkdownSplitter, Page, PageRepository
-from askpolis.logging import configure_logging, get_logger
+from askpolis.logging import get_logger
 
 from .models import Embeddings, EmbeddingsCollection
 from .repositories import EmbeddingsRepository
 
-# TODO refactor this into the get_logger function, so that we don't have to import it here.
-configure_logging()
 logger = get_logger(__name__)
 
 

--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,3 +1,0 @@
-from askpolis.logging import configure_logging
-
-configure_logging()

--- a/backend/tests/end2end/conftest.py
+++ b/backend/tests/end2end/conftest.py
@@ -15,9 +15,7 @@ from testcontainers.core.container import DockerContainer
 from testcontainers.postgres import PostgresContainer
 from testcontainers.redis import RedisContainer
 
-from askpolis.logging import configure_logging, get_logger
-
-configure_logging()
+from askpolis.logging import get_logger
 
 containers_logger = get_logger("containers")
 


### PR DESCRIPTION
The _configure_logging method is being called automatically when get_logger is called.