### PR TITLE
Refactor DB dependency

### DIFF
--- a/backend/src/askpolis/core/__init__.py
+++ b/backend/src/askpolis/core/__init__.py
@@ -1,4 +1,5 @@
 from askpolis.db import get_db
+
 from .dependencies import get_document_repository, get_parliament_repository
 from .markdown_splitter import MarkdownSplitter
 from .models import Base, Document, DocumentType, ElectionProgram, Page, Parliament, ParliamentPeriod, Party

--- a/backend/src/askpolis/core/__init__.py
+++ b/backend/src/askpolis/core/__init__.py
@@ -1,4 +1,5 @@
-from .dependencies import get_db, get_document_repository, get_parliament_repository
+from askpolis.db import get_db
+from .dependencies import get_document_repository, get_parliament_repository
 from .markdown_splitter import MarkdownSplitter
 from .models import Base, Document, DocumentType, ElectionProgram, Page, Parliament, ParliamentPeriod, Party
 from .pdf_reader import PdfDocument, PdfPage, PdfReader

--- a/backend/src/askpolis/core/dependencies.py
+++ b/backend/src/askpolis/core/dependencies.py
@@ -1,35 +1,10 @@
-import os
-from collections.abc import Generator
-from typing import Annotated, Any, Optional
+from typing import Annotated
 
 from fastapi import Depends
-from sqlalchemy import Engine, create_engine
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.orm import Session
 
+from askpolis.db import get_db
 from .repositories import DocumentRepository, ParliamentRepository
-
-engine: Optional[Engine] = None
-DbSession: Optional[sessionmaker[Session]] = None
-
-
-def get_db() -> Generator[Session, Any, None]:
-    global engine, DbSession
-    if not engine:
-        try:
-            engine = create_engine(
-                os.getenv("DATABASE_URL") or "postgresql+psycopg://postgres@postgres:5432/askpolis-db"
-            )
-        except Exception as e:
-            raise Exception("Error while connecting to database") from e
-
-    if not DbSession:
-        DbSession = sessionmaker(bind=engine)
-
-    db = DbSession()
-    try:
-        yield db
-    finally:
-        db.close()
 
 
 def get_document_repository(db: Annotated[Session, Depends(get_db)]) -> DocumentRepository:

--- a/backend/src/askpolis/core/dependencies.py
+++ b/backend/src/askpolis/core/dependencies.py
@@ -4,6 +4,7 @@ from fastapi import Depends
 from sqlalchemy.orm import Session
 
 from askpolis.db import get_db
+
 from .repositories import DocumentRepository, ParliamentRepository
 
 

--- a/backend/src/askpolis/core/tasks.py
+++ b/backend/src/askpolis/core/tasks.py
@@ -4,7 +4,6 @@ from typing import Any, Optional
 
 import uuid_utils.compat as uuid
 from celery import shared_task
-from askpolis.db import get_db
 
 from askpolis.core import Document, ElectionProgram, Parliament, ParliamentPeriod, Party
 from askpolis.core.models import DocumentType, Page
@@ -19,6 +18,7 @@ from askpolis.core.repositories import (
 )
 from askpolis.data_fetcher import FetchedData, FetchedDataRepository
 from askpolis.data_fetcher.abgeordnetenwatch import DATA_FETCHER_ID
+from askpolis.db import get_db
 from askpolis.logging import get_logger
 
 logger = get_logger(__name__)

--- a/backend/src/askpolis/data_fetcher/tasks.py
+++ b/backend/src/askpolis/data_fetcher/tasks.py
@@ -1,9 +1,8 @@
 from celery import shared_task
-from askpolis.db import get_db
 
 from askpolis.data_fetcher import FetchedDataRepository
 from askpolis.data_fetcher.abgeordnetenwatch import AbgeordnetenwatchDataFetcher
-
+from askpolis.db import get_db
 
 
 @shared_task(name="fetch_bundestag_from_abgeordnetenwatch")

--- a/backend/src/askpolis/data_fetcher/tasks.py
+++ b/backend/src/askpolis/data_fetcher/tasks.py
@@ -1,20 +1,15 @@
-import os
-
 from celery import shared_task
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+from askpolis.db import get_db
 
 from askpolis.data_fetcher import FetchedDataRepository
 from askpolis.data_fetcher.abgeordnetenwatch import AbgeordnetenwatchDataFetcher
 
-engine = create_engine(os.getenv("DATABASE_URL") or "postgresql+psycopg://postgres@postgres:5432/askpolis-db")
-DbSession = sessionmaker(bind=engine)
 
 
 @shared_task(name="fetch_bundestag_from_abgeordnetenwatch")
 def fetch_bundestag_from_abgeordnetenwatch() -> None:
     bundestag_id = 5
-    session = DbSession()
+    session = next(get_db())
     try:
         data_fetcher = AbgeordnetenwatchDataFetcher(FetchedDataRepository(session))
         data_fetcher.fetch_election_programs(bundestag_id)
@@ -24,7 +19,7 @@ def fetch_bundestag_from_abgeordnetenwatch() -> None:
 
 @shared_task(name="cleanup_outdated_data")
 def cleanup_outdated_data() -> None:
-    session = DbSession()
+    session = next(get_db())
     try:
         FetchedDataRepository(session).delete_outdated_data()
     finally:

--- a/backend/src/askpolis/db/__init__.py
+++ b/backend/src/askpolis/db/__init__.py
@@ -1,0 +1,3 @@
+from .dependencies import get_db
+
+__all__ = ["get_db"]

--- a/backend/src/askpolis/db/dependencies.py
+++ b/backend/src/askpolis/db/dependencies.py
@@ -1,0 +1,30 @@
+import os
+from collections.abc import Generator
+from typing import Any, Optional
+
+from sqlalchemy import Engine, create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+engine: Optional[Engine] = None
+DbSession: Optional[sessionmaker[Session]] = None
+
+
+def get_db() -> Generator[Session, Any, None]:
+    """Yield a database session."""
+    global engine, DbSession
+    if not engine:
+        try:
+            engine = create_engine(
+                os.getenv("DATABASE_URL") or "postgresql+psycopg://postgres@postgres:5432/askpolis-db"
+            )
+        except Exception as e:
+            raise Exception("Error while connecting to database") from e
+
+    if not DbSession:
+        DbSession = sessionmaker(bind=engine)
+
+    db = DbSession()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/src/askpolis/qa/dependencies.py
+++ b/backend/src/askpolis/qa/dependencies.py
@@ -3,7 +3,8 @@ from typing import Annotated
 from fastapi import Depends
 from sqlalchemy.orm import Session
 
-from askpolis.core import ParliamentRepository, get_db
+from askpolis.core import ParliamentRepository
+from askpolis.db import get_db
 from askpolis.search import EmbeddingsRepository, get_search_service
 
 from .agents import AnswerAgent

--- a/backend/src/askpolis/qa/tasks.py
+++ b/backend/src/askpolis/qa/tasks.py
@@ -2,8 +2,8 @@ import uuid
 from typing import Optional
 
 from celery import shared_task
-from askpolis.db import get_db
 
+from askpolis.db import get_db
 from askpolis.logging import get_logger
 
 from .models import Question

--- a/backend/src/askpolis/qa/tasks.py
+++ b/backend/src/askpolis/qa/tasks.py
@@ -1,10 +1,8 @@
-import os
 import uuid
 from typing import Optional
 
 from celery import shared_task
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+from askpolis.db import get_db
 
 from askpolis.logging import get_logger
 
@@ -13,28 +11,31 @@ from .repositories import QuestionRepository
 
 logger = get_logger(__name__)
 
-engine = create_engine(os.getenv("DATABASE_URL") or "postgresql+psycopg://postgres@postgres:5432/askpolis-db")
-DbSession = sessionmaker(bind=engine)
-
 
 @shared_task(name="answer_question_task")
 def answer_question_task(question_id: str) -> Optional[Question]:
     from .dependencies import get_qa_service
 
-    with DbSession() as session:
+    session = next(get_db())
+    try:
         qid = uuid.UUID(question_id)
         return get_qa_service(session).answer_question(qid)
+    finally:
+        session.close()
 
 
 @shared_task(name="answer_stale_questions_task")
 def answer_stale_questions_task() -> None:
-    with DbSession() as session:
+    session = next(get_db())
+    try:
         question_repository = QuestionRepository(session)
         stale_questions = question_repository.get_stale_questions()
         logger.info(f"Scheduling {len(stale_questions)} stale questions...")
         for question in stale_questions:
             answer_question_task.delay(str(question.id))
         logger.info(f"Scheduled {len(stale_questions)} stale questions")
+    finally:
+        session.close()
 
 
 class CeleryQuestionScheduler:

--- a/backend/src/askpolis/search/dependencies.py
+++ b/backend/src/askpolis/search/dependencies.py
@@ -3,7 +3,8 @@ from typing import Annotated
 from fastapi import Depends
 from sqlalchemy.orm import Session
 
-from askpolis.core import MarkdownSplitter, PageRepository, get_db
+from askpolis.core import MarkdownSplitter, PageRepository
+from askpolis.db import get_db
 
 from .embeddings_service import EmbeddingsService, get_embedding_model
 from .repositories import EmbeddingsCollectionRepository, EmbeddingsRepository

--- a/backend/src/askpolis/search/tasks.py
+++ b/backend/src/askpolis/search/tasks.py
@@ -2,9 +2,9 @@ import datetime
 import random
 
 from celery import shared_task
-from askpolis.db import get_db
 
 from askpolis.core import Document, DocumentRepository, DocumentType, MarkdownSplitter, Page, PageRepository
+from askpolis.db import get_db
 from askpolis.logging import get_logger
 
 from .embeddings_service import EmbeddingsService, get_embedding_model

--- a/backend/src/askpolis/search/tasks.py
+++ b/backend/src/askpolis/search/tasks.py
@@ -1,10 +1,8 @@
 import datetime
-import os
 import random
 
 from celery import shared_task
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+from askpolis.db import get_db
 
 from askpolis.core import Document, DocumentRepository, DocumentType, MarkdownSplitter, Page, PageRepository
 from askpolis.logging import get_logger
@@ -15,13 +13,11 @@ from .repositories import EmbeddingsCollectionRepository, EmbeddingsRepository
 
 logger = get_logger(__name__)
 
-engine = create_engine(os.getenv("DATABASE_URL") or "postgresql+psycopg://postgres@postgres:5432/askpolis-db")
-DbSession = sessionmaker(bind=engine)
-
 
 @shared_task(name="test_embeddings")
 def test_embeddings() -> None:
-    with DbSession() as session:
+    session = next(get_db())
+    try:
         collections_repository = EmbeddingsCollectionRepository(session)
         collection = collections_repository.get_most_recent_by_name("test")
         if collection is None:
@@ -54,13 +50,16 @@ def test_embeddings() -> None:
             "Computed embeddings for test document",
             {"document_id": document.id, "embeddings": len(computed_embeddings)},
         )
+    finally:
+        session.close()
 
 
 @shared_task(name="ingest_embeddings_for_one_document")
 def ingest_embeddings_for_one_document() -> None:
     splitter = MarkdownSplitter(chunk_size=2000, chunk_overlap=400)
 
-    with DbSession() as session:
+    session = next(get_db())
+    try:
         collections_repository = EmbeddingsCollectionRepository(session)
         collection = collections_repository.get_most_recent_by_name("default")
         if collection is None:
@@ -84,3 +83,5 @@ def ingest_embeddings_for_one_document() -> None:
         logger.info_with_attrs(
             "Computed embeddings for document", {"document_id": document.id, "embeddings": len(computed_embeddings)}
         )
+    finally:
+        session.close()


### PR DESCRIPTION
## Summary
- separate DB access dependency into new module `askpolis.db`
- update core, QA, and search modules to import `get_db` from the new module
- update Celery tasks to use the shared `get_db` helper

## Testing
- `PYTHONPATH=backend/src pytest backend/tests/unit/core/markdown_splitter_test.py -q` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68415f2cd7f4832da68e04ebf6d36a0e