### PR TITLE
Add validation for FetchedData json_data type

### DIFF
--- a/backend/src/askpolis/data_fetcher/models.py
+++ b/backend/src/askpolis/data_fetcher/models.py
@@ -8,7 +8,11 @@ from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import declarative_base
 
+from askpolis.logging import get_logger
+
 Base = declarative_base()
+
+logger = get_logger(__name__)
 
 
 class EntityType(str, enum.Enum):
@@ -49,7 +53,33 @@ class FetchedData(Base):
 
     @property
     def json_with_data_field(self) -> dict[str, Any]:
+        self._warn_if_json_mismatch()
+
+        if self.json_data is None:
+            return {"data": None}
+
+        is_actual_list = isinstance(self.json_data, list)
+        if self.is_list and not is_actual_list:
+            self.json_data = [self.json_data]
+        elif not self.is_list and is_actual_list:
+            self.json_data = self.json_data[0] if self.json_data else None
+
         return {"data": self.json_data}
+
+    def _warn_if_json_mismatch(self) -> None:
+        if self.json_data is None:
+            return
+        is_actual_list = isinstance(self.json_data, list)
+        if self.is_list and not is_actual_list:
+            logger.warning_with_attrs(
+                "json_data expected to be list but found non-list",
+                {"entity": self.entity},
+            )
+        elif not self.is_list and is_actual_list:
+            logger.warning_with_attrs(
+                "json_data expected to be non-list but found list",
+                {"entity": self.entity},
+            )
 
     def __repr__(self) -> str:
         return (

--- a/backend/tests/unit/data_fetcher/fetched_data_test.py
+++ b/backend/tests/unit/data_fetcher/fetched_data_test.py
@@ -1,0 +1,46 @@
+import logging
+
+import pytest
+
+from askpolis.data_fetcher.models import DataFetcherType, EntityType, FetchedData
+
+
+@pytest.mark.parametrize(
+    "is_list,json_data,expected_json,warn",
+    [
+        (True, [{"a": 1}], [{"a": 1}], False),
+        (True, {"a": 1}, [{"a": 1}], True),
+        (False, {"a": 1}, {"a": 1}, False),
+        (False, [{"a": 1}, {"a": 2}], {"a": 1}, True),
+        (False, [], None, True),
+        (True, [], [], False),
+        (True, None, None, False),
+        (False, None, None, False),
+    ],
+)
+def test_json_with_data_field_converts_and_warns(
+    is_list: bool,
+    json_data: list | dict | None,
+    expected_json: list | dict | None,
+    warn: bool,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.WARNING)
+    fetched_data = FetchedData(
+        data_fetcher="fetcher",
+        data_fetcher_type=DataFetcherType.ABGEORDNETENWATCH,
+        source="src",
+        entity="entity",
+        entity_type=EntityType.PARTY,
+        is_list=is_list,
+        json_data=json_data,
+    )
+    result = fetched_data.json_with_data_field
+
+    assert result == {"data": expected_json}
+    assert fetched_data.json_data == expected_json
+
+    if warn:
+        assert any("json_data expected" in record.getMessage() for record in caplog.records)
+    else:
+        assert not caplog.records


### PR DESCRIPTION
## Summary
- warn if `json_data` doesn't match the `is_list` flag
- check JSON structure when saving or retrieving `FetchedData`

## Testing
- `ruff format backend/src/askpolis/data_fetcher/repositories.py backend/tests/unit/data_fetcher/fetched_data_test.py backend/src/askpolis/data_fetcher/models.py`
- `ruff check backend/src/askpolis/data_fetcher/repositories.py backend/tests/unit/data_fetcher/fetched_data_test.py backend/src/askpolis/data_fetcher/models.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'redis')*

------
https://chatgpt.com/codex/tasks/task_e_68416011ad14832daba5383d586907ce