### PR TITLE
Add answer to question response

### DIFF
--- a/backend/src/askpolis/qa/routes.py
+++ b/backend/src/askpolis/qa/routes.py
@@ -77,7 +77,7 @@ def get_question(
 
         answer_response = AnswerResponse(
             answer=answer.contents[0].content,
-            language=answer.contents[0].language,
+            language=answer.contents[0].language.strip(),
             status="completed",
             citations=citation_responses,
             created_at=answer.created_at.isoformat(),

--- a/backend/src/askpolis/qa/routes.py
+++ b/backend/src/askpolis/qa/routes.py
@@ -50,7 +50,40 @@ def create_question(
 def get_question(
     request: Request,
     question: Annotated[Question, Depends(get_question_from_path)],
+    document_repository: Annotated[DocumentRepository, Depends(get_document_repository)],
+    embeddings_repository: Annotated[EmbeddingsRepository, Depends(get_embeddings_repository)],
 ) -> QuestionResponse:
+    if len(question.answers) == 0:
+        answer_response = AnswerResponse(status="in_progress", citations=[])
+    else:
+        answer = question.answers[0]
+        if len(answer.contents) == 0:
+            raise HTTPException(status_code=500, detail="Answer without content pieces should not exist")
+
+        citation_responses: list[CitationResponse] = []
+        for cit in answer.citations:
+            doc = document_repository.get(cit.document_id)
+            emb = embeddings_repository.get(cit.embeddings_id)
+
+            title = doc.name if doc and doc.name else "Unknown"
+            content = emb.chunk if emb and emb.chunk else "Unknown"
+
+            citation_responses.append(
+                CitationResponse(
+                    title=title,
+                    content=content,
+                )
+            )
+
+        answer_response = AnswerResponse(
+            answer=answer.contents[0].content,
+            language=answer.contents[0].language,
+            status="completed",
+            citations=citation_responses,
+            created_at=answer.created_at.isoformat(),
+            updated_at=answer.updated_at.isoformat(),
+        )
+
     return QuestionResponse(
         id=question.id,
         content=question.content,
@@ -58,6 +91,7 @@ def get_question(
         answer_url=str(request.url_for("get_answer", question_id=question.id)),
         created_at=question.created_at.isoformat(),
         updated_at=question.updated_at.isoformat(),
+        answer=answer_response,
     )
 
 

--- a/backend/tests/unit/qa/routes_test.py
+++ b/backend/tests/unit/qa/routes_test.py
@@ -1,0 +1,40 @@
+import uuid
+from unittest.mock import MagicMock
+
+from fastapi.testclient import TestClient
+
+from askpolis.core import get_document_repository
+from askpolis.main import app
+from askpolis.qa.dependencies import get_qa_service
+from askpolis.qa.models import Answer, AnswerContent, Question
+from askpolis.search import get_embeddings_repository
+
+
+class DummyQAService:
+    def __init__(self, question: Question) -> None:
+        self.question = question
+
+    def get_question(self, question_id: uuid.UUID) -> Question | None:
+        if question_id == self.question.id:
+            return self.question
+        return None
+
+
+def test_get_question_returns_answer() -> None:
+    question = Question("What is the answer?")
+    answer = Answer(contents=[AnswerContent("en-US", "42")], citations=[])
+    answer.question_id = question.id
+    question.answers.append(answer)
+
+    app.dependency_overrides[get_qa_service] = lambda: DummyQAService(question)
+    app.dependency_overrides[get_document_repository] = lambda: MagicMock()
+    app.dependency_overrides[get_embeddings_repository] = lambda: MagicMock()
+
+    client = TestClient(app)
+    response = client.get(f"/v0/questions/{question.id}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["answer"]["answer"] == "42"
+    assert data["status"] == "answered"
+
+    app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- include answer info in `/questions/{id}` endpoint
- test that questions endpoint returns the answer when present

## Testing
- `poetry run pre-commit run --files src/askpolis/qa/routes.py tests/unit/qa/routes_test.py`
- `poetry run mypy .`
- `poetry run pytest -v -m unit`


------
https://chatgpt.com/codex/tasks/task_e_6850a2e608d8832d88c746455f72ad6f