### PR TITLE
Fix trailing whitespace in language code

### DIFF
--- a/backend/src/askpolis/qa/routes.py
+++ b/backend/src/askpolis/qa/routes.py
@@ -100,7 +100,7 @@ def get_answer(
 
     return AnswerResponse(
         answer=answer.contents[0].content,
-        language=answer.contents[0].language,
+        language=answer.contents[0].language.strip(),
         status="completed",
         citations=citation_responses,
         created_at=answer.created_at.isoformat(),

--- a/backend/tests/unit/qa/routes_test.py
+++ b/backend/tests/unit/qa/routes_test.py
@@ -1,0 +1,18 @@
+from unittest.mock import MagicMock
+
+from askpolis.qa.models import Answer, AnswerContent, Question
+from askpolis.qa.routes import get_answer
+
+
+def test_get_answer_trims_language_code() -> None:
+    question = Question(content="test")
+    answer = Answer(contents=[AnswerContent(language="de   ", content="hi")], citations=[])
+    question.answers.append(answer)
+
+    response = get_answer(
+        question=question,
+        document_repository=MagicMock(),
+        embeddings_repository=MagicMock(),
+    )
+
+    assert response.language == "de"


### PR DESCRIPTION
## Summary
- ensure answer language codes have no trailing whitespace
- add unit test for language formatting

## Testing
- `poetry run pre-commit run --files src/askpolis/qa/routes.py tests/unit/qa/routes_test.py`
- `poetry run mypy .`
- `poetry run pytest -v -m unit`

------
https://chatgpt.com/codex/tasks/task_e_6850a33a9e4c832d9a265aa6989052a9