### PR TITLE
Add DOCKER_HOME support for log fetcher

### DIFF
--- a/backend/compose.yaml
+++ b/backend/compose.yaml
@@ -79,11 +79,13 @@ services:
     image: fluent/fluent-bit:3.2.4
     container_name: fluent-bit
     user: root # Run as root to access log files
+    environment:
+      - DOCKER_HOME=${DOCKER_HOME:-/var/lib/docker}
     volumes:
       - ../infrastructure/configs/fluent-bit/fluent-bit-compose.conf:/fluent-bit/etc/fluent-bit.conf
       - ../infrastructure/configs/fluent-bit/parser.conf:/fluent-bit/etc/parser.conf
       - ../infrastructure/configs/fluent-bit/docker-metadata.lua:/fluent-bit/etc/docker-metadata.lua
-      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - ${DOCKER_HOME:-/var/lib/docker}/containers:${DOCKER_HOME:-/var/lib/docker}/containers:ro
       - /var/log:/var/log:ro
     depends_on:
       - otel-collector

--- a/infrastructure/configs/fluent-bit/docker-metadata.lua
+++ b/infrastructure/configs/fluent-bit/docker-metadata.lua
@@ -1,5 +1,6 @@
 -- base version from https://github.com/fluent/fluent-bit/issues/1499
-DOCKER_VAR_DIR = '/var/lib/docker/containers/'
+DOCKER_HOME = os.getenv('DOCKER_HOME') or '/var/lib/docker'
+DOCKER_VAR_DIR = DOCKER_HOME .. '/containers/'
 DOCKER_CONTAINER_CONFIG_FILE = '/config.v2.json'
 CACHE_TTL_SEC = 300
 

--- a/infrastructure/configs/fluent-bit/fluent-bit-compose.conf
+++ b/infrastructure/configs/fluent-bit/fluent-bit-compose.conf
@@ -5,7 +5,7 @@
 
 [INPUT]
     Name            tail
-    Path            /var/lib/docker/containers/*/*json.log
+    Path            ${DOCKER_HOME}/containers/*/*json.log
     Parser          docker
     Tag             docker.*
     Docker_Mode     On


### PR DESCRIPTION
## Summary
- allow configuring Docker log path in Fluent Bit
- add DOCKER_HOME environment variable in docker metadata script
- mount custom Docker path for the fluent-bit service

## Testing
- `poetry run pre-commit run --files ../infrastructure/configs/fluent-bit/fluent-bit-compose.conf ../infrastructure/configs/fluent-bit/docker-metadata.lua compose.yaml`
- `poetry run pytest -v -m unit`

------
https://chatgpt.com/codex/tasks/task_e_6850a4ca18ec832dbc1b15a4bf9fb0c6