### PR TITLE
Refactor Page DB access into Document model

### DIFF
--- a/backend/src/askpolis/core/__init__.py
+++ b/backend/src/askpolis/core/__init__.py
@@ -2,7 +2,6 @@ from askpolis.db import get_db
 
 from .dependencies import (
     get_document_repository,
-    get_page_repository,
     get_parliament_repository,
 )
 from .markdown_splitter import MarkdownSplitter
@@ -19,7 +18,7 @@ from .models import (
     Party,
 )
 from .pdf_reader import PdfDocument, PdfPage, PdfReader
-from .repositories import DocumentRepository, PageRepository, ParliamentRepository
+from .repositories import DocumentRepository, ParliamentRepository
 from .routes import router
 
 __all__ = [
@@ -31,12 +30,10 @@ __all__ = [
     "ElectionProgram",
     "get_db",
     "get_document_repository",
-    "get_page_repository",
     "get_parliament_repository",
     "MarkdownSplitter",
     "router",
     "Page",
-    "PageRepository",
     "PageResponse",
     "Parliament",
     "ParliamentRepository",

--- a/backend/src/askpolis/core/dependencies.py
+++ b/backend/src/askpolis/core/dependencies.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Session
 
 from askpolis.db import get_db
 
-from .repositories import DocumentRepository, PageRepository, ParliamentRepository
+from .repositories import DocumentRepository, ParliamentRepository
 
 
 def get_document_repository(db: Annotated[Session, Depends(get_db)]) -> DocumentRepository:
@@ -14,7 +14,3 @@ def get_document_repository(db: Annotated[Session, Depends(get_db)]) -> Document
 
 def get_parliament_repository(db: Annotated[Session, Depends(get_db)]) -> ParliamentRepository:
     return ParliamentRepository(db)
-
-
-def get_page_repository(db: Annotated[Session, Depends(get_db)]) -> PageRepository:
-    return PageRepository(db)

--- a/backend/src/askpolis/core/models.py
+++ b/backend/src/askpolis/core/models.py
@@ -19,7 +19,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.orm import Mapped, declarative_base, mapped_column
+from sqlalchemy.orm import Mapped, declarative_base, mapped_column, relationship
 
 Base = declarative_base()
 
@@ -52,6 +52,8 @@ class Page(Base):
     raw_content: str = Column(String, nullable=False)
     page_metadata = Column(JSONB, nullable=True)
     updated_at = Column(DateTime, nullable=False, default=lambda: datetime.datetime.now(datetime.UTC))
+
+    document: Mapped["Document"] = relationship("Document", back_populates="pages")
 
     def to_langchain_document(self) -> LangchainDocument:
         return LangchainDocument(page_content=self.content, metadata=self.page_metadata)
@@ -92,6 +94,8 @@ class Document(Base):
     reference_id_1: Mapped[Optional[uuid.UUID]] = mapped_column(DB_UUID(as_uuid=True), nullable=True)
     reference_id_2: Mapped[Optional[uuid.UUID]] = mapped_column(DB_UUID(as_uuid=True), nullable=True)
     updated_at = Column(DateTime, nullable=False, default=lambda: datetime.datetime.now(datetime.UTC))
+
+    pages: Mapped[list[Page]] = relationship("Page", back_populates="document", cascade="all, delete-orphan")
 
     __table_args__ = (
         Index(

--- a/backend/src/askpolis/core/repositories.py
+++ b/backend/src/askpolis/core/repositories.py
@@ -8,21 +8,6 @@ from sqlalchemy.orm import Session
 from .models import Document, ElectionProgram, Page, Parliament, ParliamentPeriod, Party
 
 
-class PageRepository:
-    def __init__(self, db: Session):
-        self.db = db
-
-    def get(self, page_id: uuid.UUID) -> Optional[Page]:
-        return self.db.query(Page).filter(Page.id == page_id).first()
-
-    def get_by_document_id(self, document_id: uuid.UUID) -> list[Page]:
-        return self.db.query(Page).filter(Page.document_id == document_id).all()
-
-    def save_all(self, pages: list[Page]) -> None:
-        self.db.add_all(pages)
-        self.db.commit()
-
-
 class DocumentRepository:
     def __init__(self, db: Session):
         self.db = db
@@ -46,6 +31,22 @@ class DocumentRepository:
     def save(self, document: Document) -> None:
         self.db.add(document)
         self.db.commit()
+
+    def add_pages(self, document: Document, pages: list[Page]) -> None:
+        document.pages.extend(pages)
+        self.db.commit()
+
+    def get_pages(self, document_id: uuid.UUID) -> list[Page]:
+        document = self.get(document_id)
+        if document is None:
+            return []
+        return list(document.pages)
+
+    def get_page(self, document_id: uuid.UUID, page_id: uuid.UUID) -> Optional[Page]:
+        document = self.get(document_id)
+        if document is None:
+            return None
+        return next((p for p in document.pages if p.id == page_id), None)
 
 
 class ParliamentRepository:

--- a/backend/src/askpolis/core/routes.py
+++ b/backend/src/askpolis/core/routes.py
@@ -7,7 +7,6 @@ from fastapi.responses import JSONResponse
 
 from .dependencies import (
     get_document_repository,
-    get_page_repository,
     get_parliament_repository,
 )
 from .models import (
@@ -17,7 +16,7 @@ from .models import (
     Parliament,
     ParliamentResponse,
 )
-from .repositories import DocumentRepository, PageRepository, ParliamentRepository
+from .repositories import DocumentRepository, ParliamentRepository
 
 router = APIRouter()
 
@@ -70,13 +69,12 @@ def get_document_page(
     document_id: Annotated[uuid.UUID, Path()],
     page_id: Annotated[uuid.UUID, Path()],
     document_repository: Annotated[DocumentRepository, Depends(get_document_repository)],
-    page_repository: Annotated[PageRepository, Depends(get_page_repository)],
 ) -> PageResponse:
     document = document_repository.get(document_id)
     if document is None:
         raise HTTPException(status_code=404, detail="Document not found")
-    page = page_repository.get(page_id)
-    if page is None or page.document_id != document_id:
+    page = document_repository.get_page(document_id, page_id)
+    if page is None:
         raise HTTPException(status_code=404, detail="Page not found")
     return PageResponse(
         id=page.id,

--- a/backend/src/askpolis/core/tasks.py
+++ b/backend/src/askpolis/core/tasks.py
@@ -11,7 +11,6 @@ from askpolis.core.pdf_reader import PdfReader
 from askpolis.core.repositories import (
     DocumentRepository,
     ElectionProgramRepository,
-    PageRepository,
     ParliamentPeriodRepository,
     ParliamentRepository,
     PartyRepository,
@@ -183,7 +182,6 @@ def read_and_parse_election_programs_to_documents() -> None:
     try:
         election_program_repository = ElectionProgramRepository(session)
         document_repository = DocumentRepository(session)
-        page_repository = PageRepository(session)
 
         election_programs = election_program_repository.get_all_without_referenced_document()
         for election_program in election_programs:
@@ -248,7 +246,7 @@ def read_and_parse_election_programs_to_documents() -> None:
                     )
                     for pdf_page in pdf_document.pages
                 ]
-                page_repository.save_all(pages)
+                document_repository.add_pages(document, pages)
     finally:
         session.close()
 

--- a/backend/src/askpolis/search/dependencies.py
+++ b/backend/src/askpolis/search/dependencies.py
@@ -3,7 +3,7 @@ from typing import Annotated
 from fastapi import Depends
 from sqlalchemy.orm import Session
 
-from askpolis.core import MarkdownSplitter, PageRepository
+from askpolis.core import DocumentRepository, MarkdownSplitter
 from askpolis.db import get_db
 
 from .embeddings_service import EmbeddingsService, get_embedding_model
@@ -20,8 +20,8 @@ def get_search_service(
     db: Annotated[Session, Depends(get_db)],
     embeddings_repository: Annotated[EmbeddingsRepository, Depends(get_embeddings_repository)],
 ) -> SearchServiceBase:
-    page_repository = PageRepository(db)
+    document_repository = DocumentRepository(db)
     splitter = MarkdownSplitter(chunk_size=2000, chunk_overlap=400)
-    embeddings_service = EmbeddingsService(page_repository, embeddings_repository, get_embedding_model(), splitter)
+    embeddings_service = EmbeddingsService(document_repository, embeddings_repository, get_embedding_model(), splitter)
     reranker_service = RerankerService()
     return SearchService(EmbeddingsCollectionRepository(db), embeddings_service, reranker_service)

--- a/backend/src/askpolis/search/embeddings_service.py
+++ b/backend/src/askpolis/search/embeddings_service.py
@@ -7,7 +7,7 @@ import numpy.typing as npt
 from FlagEmbedding import BGEM3FlagModel
 from FlagEmbedding.inference.embedder.encoder_only.m3 import M3Embedder
 
-from askpolis.core import Document, MarkdownSplitter, Page, PageRepository
+from askpolis.core import Document, DocumentRepository, MarkdownSplitter, Page
 from askpolis.logging import get_logger
 
 from .models import Embeddings, EmbeddingsCollection
@@ -104,12 +104,12 @@ def get_embedding_model() -> FakeModel | M3Embedder:
 class EmbeddingsService:
     def __init__(
         self,
-        page_repository: PageRepository,
+        document_repository: DocumentRepository,
         embeddings_repository: EmbeddingsRepository,
         model: FakeModel | M3Embedder,
         splitter: MarkdownSplitter,
     ):
-        self._page_repository = page_repository
+        self._document_repository = document_repository
         self._embeddings_repository = embeddings_repository
         self._splitter = splitter
         self._model = model
@@ -132,7 +132,7 @@ class EmbeddingsService:
         return _rrf_merge(dense_results, sparse_results)[:limit]
 
     def embed_document(self, collection: EmbeddingsCollection, document: Document) -> list[Embeddings]:
-        pages = self._page_repository.get_by_document_id(document.id)
+        pages = self._document_repository.get_pages(document.id)
         if len(pages) == 0:
             logger.warning_with_attrs("No pages found for document", {"document_id": document.id})
             return []

--- a/backend/tests/integration/core/repositories_test.py
+++ b/backend/tests/integration/core/repositories_test.py
@@ -11,7 +11,6 @@ from askpolis.core import (
     DocumentType,
     ElectionProgram,
     Page,
-    PageRepository,
     Parliament,
     ParliamentPeriod,
     Party,
@@ -96,8 +95,7 @@ def test_document_and_page_model(db_session: Session) -> None:
     assert document_from_db is not None
     assert document_from_db.name == "test"
 
-    page_repository = PageRepository(db_session)
-    pages = page_repository.get_by_document_id(document_from_db.id)
+    pages = document_repository.get_pages(document_from_db.id)
     assert len(pages) == 1
     assert pages[0].content == "some content"
 

--- a/backend/tests/unit/core/routes_test.py
+++ b/backend/tests/unit/core/routes_test.py
@@ -6,7 +6,6 @@ from askpolis.core import (
     DocumentType,
     Page,
     get_document_repository,
-    get_page_repository,
 )
 from askpolis.main import app
 from askpolis.search.dependencies import get_search_service
@@ -19,9 +18,10 @@ def setup_client(doc: Document, page: Page) -> TestClient:
         def get(self, doc_id: uuid.UUID) -> Document | None:
             return doc if doc_id == doc.id else None
 
-    class PageRepo:
-        def get(self, page_id: uuid.UUID) -> Page | None:
-            return page if page_id == page.id else None
+        def get_page(self, doc_id: uuid.UUID, page_id: uuid.UUID) -> Page | None:
+            if doc_id == doc.id and page_id == page.id:
+                return page
+            return None
 
     class DummySearch(SearchServiceBase):
         def find_matching_texts(
@@ -38,7 +38,6 @@ def setup_client(doc: Document, page: Page) -> TestClient:
             ]
 
     app.dependency_overrides[get_document_repository] = lambda: DocRepo()
-    app.dependency_overrides[get_page_repository] = lambda: PageRepo()
     app.dependency_overrides[get_search_service] = lambda: DummySearch()
 
     return TestClient(app)

--- a/backend/tests/unit/search/embeddings_service_test.py
+++ b/backend/tests/unit/search/embeddings_service_test.py
@@ -9,7 +9,7 @@ from askpolis.search.models import convert_to_sparse_vector
 
 
 @pytest.fixture
-def mock_page_repository() -> Mock:
+def mock_document_repository() -> Mock:
     return MagicMock()
 
 
@@ -30,10 +30,10 @@ def mock_splitter() -> Mock:
 
 @pytest.fixture
 def embeddings_service(
-    mock_page_repository: Mock, mock_embeddings_repository: Mock, mock_model: Mock, mock_splitter: Mock
+    mock_document_repository: Mock, mock_embeddings_repository: Mock, mock_model: Mock, mock_splitter: Mock
 ) -> EmbeddingsService:
     return EmbeddingsService(
-        page_repository=mock_page_repository,
+        document_repository=mock_document_repository,
         embeddings_repository=mock_embeddings_repository,
         model=mock_model,
         splitter=mock_splitter,
@@ -42,7 +42,7 @@ def embeddings_service(
 
 def test_embed_document(
     embeddings_service: EmbeddingsService,
-    mock_page_repository: Mock,
+    mock_document_repository: Mock,
     mock_embeddings_repository: Mock,
     mock_model: Mock,
     mock_splitter: Mock,
@@ -56,7 +56,7 @@ def test_embed_document(
         raw_content="Raw Content",
         page_metadata={"page": 1},
     )
-    mock_page_repository.get_by_document_id.return_value = [page]
+    mock_document_repository.get_pages.return_value = [page]
     chunk = MagicMock()
     chunk.page_content = "Chunk content"
     chunk.metadata = {"page": 1, "chunk_id": 0}
@@ -94,7 +94,7 @@ def test_embed_document(
 
 def test_embed_document_sets_correct_page(
     embeddings_service: EmbeddingsService,
-    mock_page_repository: Mock,
+    mock_document_repository: Mock,
     mock_embeddings_repository: Mock,
     mock_model: Mock,
     mock_splitter: Mock,
@@ -108,7 +108,7 @@ def test_embed_document_sets_correct_page(
     page2 = Page(
         document_id=document.id, page_number=2, content="Test Content 2", raw_content="Raw 2", page_metadata={"page": 2}
     )
-    mock_page_repository.get_by_document_id.return_value = [page1, page2]
+    mock_document_repository.get_pages.return_value = [page1, page2]
 
     chunk1 = MagicMock()
     chunk1.page_content = "Chunk content 1"


### PR DESCRIPTION
## Summary
- manage page relations via `Document` SQLAlchemy model
- remove dedicated `PageRepository` usage
- adjust dependencies, tasks and services to use `DocumentRepository`
- update unit and integration tests

## Testing
- `pre-commit run --files src/askpolis/core/models.py src/askpolis/core/repositories.py src/askpolis/core/dependencies.py src/askpolis/core/__init__.py src/askpolis/search/embeddings_service.py src/askpolis/search/dependencies.py src/askpolis/search/tasks.py src/askpolis/core/routes.py src/askpolis/core/tasks.py tests/unit/search/embeddings_service_test.py tests/unit/core/routes_test.py tests/integration/core/repositories_test.py`
- `poetry run mypy .`
- `poetry run pytest -v -m unit`


------
https://chatgpt.com/codex/tasks/task_e_686f7b8bd374832d9a14694b8dc5cc62