### PR TITLE
Add unique name indexes

### DIFF
--- a/backend/src/alembic/versions/556e6bab86d4_add_unique_name_indexes.py
+++ b/backend/src/alembic/versions/556e6bab86d4_add_unique_name_indexes.py
@@ -1,0 +1,28 @@
+"""add_unique_name_indexes
+
+Revision ID: 556e6bab86d4
+Revises: 323cf93d21fb
+Create Date: 2025-07-10 08:41:29.338609
+
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "556e6bab86d4"
+down_revision: Union[str, None] = "323cf93d21fb"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index("uq_parliaments_name", "parliaments", ["name"], unique=True)
+    op.create_index("uq_parties_name", "parties", ["name"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("uq_parties_name", table_name="parties")
+    op.drop_index("uq_parliaments_name", table_name="parliaments")

--- a/backend/src/askpolis/core/models.py
+++ b/backend/src/askpolis/core/models.py
@@ -106,6 +106,7 @@ class Document(Base):
 
 class Parliament(Base):
     __tablename__ = "parliaments"
+    __table_args__ = (Index("uq_parliaments_name", "name", unique=True),)
 
     def __init__(self, name: str, short_name: str, **kw: Any) -> None:
         super().__init__(**kw)
@@ -122,6 +123,7 @@ class Parliament(Base):
 
 class Party(Base):
     __tablename__ = "parties"
+    __table_args__ = (Index("uq_parties_name", "name", unique=True),)
 
     def __init__(self, name: str, short_name: str, **kw: Any) -> None:
         super().__init__(**kw)


### PR DESCRIPTION
## Summary
- add unique index migration on `parliaments.name` and `parties.name`
- enforce unique name index in SQLAlchemy models

## Testing
- `pre-commit run --files src/askpolis/core/models.py src/alembic/versions/556e6bab86d4_add_unique_name_indexes.py`
- `mypy .`
- `pytest -v -m unit`


------
https://chatgpt.com/codex/tasks/task_e_686f7bf618cc832dba3f63921d9b57da