### PR TITLE
Use token counts for markdown splitting

### DIFF
--- a/backend/src/askpolis/search/tasks.py
+++ b/backend/src/askpolis/search/tasks.py
@@ -62,7 +62,8 @@ def test_embeddings() -> None:
 
 @shared_task(name="ingest_embeddings_for_one_document")
 def ingest_embeddings_for_one_document() -> None:
-    splitter = MarkdownSplitter(chunk_size=2000, chunk_overlap=400)
+    # TODO change to parameters of the installation, overridable in tenant configuration
+    splitter = MarkdownSplitter(chunk_size=500, chunk_overlap=100)
 
     session = next(get_db())
     try:


### PR DESCRIPTION
## Summary
- configure `MarkdownSplitter` to count tokens using the bge tokenizer
- fall back to character length when tokenizer isn't available

## Testing
- `poetry run pre-commit run --files src/askpolis/core/markdown_splitter.py`
- `poetry run mypy .`
- `poetry run pytest -v -m unit`


------
https://chatgpt.com/codex/tasks/task_e_686f7d5b1f94832dbab1b7f788d9b50e