### PR TITLE
Add rate limiting middleware

### DIFF
--- a/backend/compose.yaml
+++ b/backend/compose.yaml
@@ -6,6 +6,7 @@ services:
     ports:
       - "8000:8000"
     environment:
+      - REDIS_URL=redis://redis:6379
       - CELERY_BROKER_URL=redis://redis:6379/0
       - OLLAMA_URL=http://ollama:11434/v1
       - DATABASE_URL=postgresql+psycopg://postgres:secret@postgres:5432/askpolis-db

--- a/backend/src/askpolis/main.py
+++ b/backend/src/askpolis/main.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 from askpolis.core import router as core_router
 from askpolis.logging import get_logger
 from askpolis.qa import router as qa_router
+from askpolis.rate_limiting import RateLimitMiddleware
 from askpolis.search import router as search_router
 
 logger = get_logger(__name__)
@@ -13,6 +14,7 @@ api_version = "v0"
 api_base_path = f"/{api_version}"
 
 app = FastAPI()
+app.add_middleware(RateLimitMiddleware)
 app.include_router(core_router, prefix=api_base_path)
 app.include_router(qa_router, prefix=api_base_path)
 app.include_router(search_router, prefix=api_base_path)

--- a/backend/src/askpolis/rate_limiting.py
+++ b/backend/src/askpolis/rate_limiting.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Awaitable
+from typing import Any, Callable, Protocol, cast
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import Response
+from starlette.status import HTTP_429_TOO_MANY_REQUESTS
+from starlette.types import ASGIApp
+
+try:
+    import redis.asyncio as redis_asyncio
+except Exception:  # pragma: no cover - redis not installed
+    redis_asyncio = None  # type: ignore[assignment]
+
+
+class RedisLike(Protocol):
+    async def incr(self, key: str) -> int: ...
+
+    async def expire(self, key: str, ttl: int) -> Any: ...
+
+
+class RateLimitMiddleware(BaseHTTPMiddleware):
+    """Simple IP based rate limiting middleware."""
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        redis_client: RedisLike | None = None,
+        limit: int = 5,
+        period: int = 60,
+    ) -> None:
+        super().__init__(app)
+        if redis_client is None:
+            if redis_asyncio is None:
+                raise RuntimeError("redis package not available")
+            url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+            redis_client = cast(RedisLike, cast(Any, redis_asyncio).from_url(url))
+        self.redis = redis_client
+        self.limit = limit
+        self.period = period
+
+    async def dispatch(self, request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
+        client_ip = request.client.host if request.client else "unknown"
+        key = f"rate-limit:{client_ip}"
+        try:
+            count = await self.redis.incr(key)
+            if count == 1:
+                await self.redis.expire(key, self.period)
+            if count > self.limit:
+                return Response(status_code=HTTP_429_TOO_MANY_REQUESTS)
+        except Exception:
+            # fail open on Redis errors
+            pass
+        return await call_next(request)

--- a/backend/src/askpolis/rate_limiting.py
+++ b/backend/src/askpolis/rate_limiting.py
@@ -4,16 +4,12 @@ import os
 from collections.abc import Awaitable
 from typing import Any, Callable, Protocol, cast
 
+import redis.asyncio as redis_asyncio
 from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import Response
 from starlette.status import HTTP_429_TOO_MANY_REQUESTS
 from starlette.types import ASGIApp
-
-try:
-    import redis.asyncio as redis_asyncio
-except Exception:  # pragma: no cover - redis not installed
-    redis_asyncio = None  # type: ignore[assignment]
 
 
 class RedisLike(Protocol):
@@ -23,7 +19,7 @@ class RedisLike(Protocol):
 
 
 class RateLimitMiddleware(BaseHTTPMiddleware):
-    """Simple IP based rate limiting middleware."""
+    """Simple IP-based rate limiting middleware."""
 
     def __init__(
         self,
@@ -35,8 +31,6 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
     ) -> None:
         super().__init__(app)
         if redis_client is None:
-            if redis_asyncio is None:
-                raise RuntimeError("redis package not available")
             url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
             redis_client = cast(RedisLike, cast(Any, redis_asyncio).from_url(url))
         self.redis = redis_client

--- a/backend/tests/unit/rate_limit_middleware_test.py
+++ b/backend/tests/unit/rate_limit_middleware_test.py
@@ -1,0 +1,37 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from askpolis.rate_limiting import RateLimitMiddleware, RedisLike
+
+
+class DummyRedis(RedisLike):
+    def __init__(self) -> None:
+        self.data: dict[str, int] = {}
+
+    async def incr(self, key: str) -> int:
+        self.data[key] = self.data.get(key, 0) + 1
+        return self.data[key]
+
+    async def expire(self, key: str, ttl: int) -> None:  # noqa: D401 - simple dummy
+        self.data.setdefault(key, 0)
+        return None
+
+
+def create_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(RateLimitMiddleware, redis_client=DummyRedis(), limit=5, period=60)
+
+    @app.get("/")
+    def read_root() -> dict[str, str]:
+        return {"hello": "world"}
+
+    return app
+
+
+def test_rate_limit_blocks_after_five_requests() -> None:
+    client = TestClient(create_app())
+    for _ in range(5):
+        resp = client.get("/")
+        assert resp.status_code == 200
+    resp = client.get("/")
+    assert resp.status_code == 429


### PR DESCRIPTION
## Summary
- add `RateLimitMiddleware` using Redis
- plug middleware into the FastAPI app
- test rate limiting behavior

## Testing
- `poetry run pre-commit run --files src/askpolis/main.py src/askpolis/rate_limiting.py tests/unit/rate_limit_middleware_test.py`
- `poetry run mypy .`
- `poetry run pytest -v -m unit`

------
https://chatgpt.com/codex/tasks/task_e_68721a10aaf4832dac40225834a78fec