### PR TITLE
Add health probes

### DIFF
--- a/backend/src/askpolis/main.py
+++ b/backend/src/askpolis/main.py
@@ -27,3 +27,15 @@ class HealthResponse(BaseModel):
 @app.get("/")
 def read_root() -> HealthResponse:
     return HealthResponse(healthy=True)
+
+
+@app.get("/healthz", include_in_schema=False)
+def liveness_probe() -> HealthResponse:
+    """Endpoint used by Kubernetes liveness probe."""
+    return HealthResponse(healthy=True)
+
+
+@app.get("/readyz", include_in_schema=False)
+def readiness_probe() -> HealthResponse:
+    """Endpoint used by Kubernetes readiness probe."""
+    return HealthResponse(healthy=True)

--- a/backend/tests/unit/probes_test.py
+++ b/backend/tests/unit/probes_test.py
@@ -1,0 +1,17 @@
+from fastapi.testclient import TestClient
+
+from askpolis.main import app
+
+client = TestClient(app)
+
+
+def test_liveness_probe() -> None:
+    resp = client.get("/healthz")
+    assert resp.status_code == 200
+    assert resp.json() == {"healthy": True}
+
+
+def test_readiness_probe() -> None:
+    resp = client.get("/readyz")
+    assert resp.status_code == 200
+    assert resp.json() == {"healthy": True}


### PR DESCRIPTION
## Summary
- add liveness and readiness probe endpoints
- test new health probe endpoints

## Testing
- `poetry run pre-commit run --files src/askpolis/main.py tests/unit/probes_test.py`
- `poetry run mypy .`
- `poetry run pytest -v -m unit`


------
https://chatgpt.com/codex/tasks/task_e_6887a58aaa6c832dac0957992a5fde43