### PR TITLE
Skip rate limit on health endpoints

### DIFF
--- a/backend/tests/unit/rate_limit_middleware_test.py
+++ b/backend/tests/unit/rate_limit_middleware_test.py
@@ -25,13 +25,42 @@ def create_app() -> FastAPI:
     def read_root() -> dict[str, str]:
         return {"hello": "world"}
 
+    @app.get("/foo")
+    def foo() -> dict[str, str]:
+        return {"foo": "bar"}
+
+    @app.get("/healthz")
+    def health() -> dict[str, bool]:
+        return {"healthy": True}
+
+    @app.get("/readyz")
+    def ready() -> dict[str, bool]:
+        return {"healthy": True}
+
     return app
 
 
 def test_rate_limit_blocks_after_five_requests() -> None:
     client = TestClient(create_app())
     for _ in range(5):
+        resp = client.get("/foo")
+        assert resp.status_code == 200
+    resp = client.get("/foo")
+    assert resp.status_code == 429
+
+
+def test_root_not_rate_limited() -> None:
+    client = TestClient(create_app())
+    for _ in range(10):
         resp = client.get("/")
         assert resp.status_code == 200
-    resp = client.get("/")
-    assert resp.status_code == 429
+
+
+def test_probes_not_rate_limited() -> None:
+    client = TestClient(create_app())
+    for _ in range(10):
+        resp = client.get("/healthz")
+        assert resp.status_code == 200
+    for _ in range(10):
+        resp = client.get("/readyz")
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- exclude `/`, `/healthz` and `/readyz` from rate limiting
- test that these endpoints are skipped while other routes still have limits

## Testing
- `poetry run pre-commit run --files src/askpolis/rate_limiting.py tests/unit/rate_limit_middleware_test.py`
- `poetry run mypy src/askpolis/rate_limiting.py tests/unit/rate_limit_middleware_test.py`
- `poetry run pytest -v -m unit`


------
https://chatgpt.com/codex/tasks/task_e_6887aaf618bc832d8dd4331750e29794