### PR TITLE
feat(backend): support forwarded IP headers in rate limiting

### DIFF
--- a/backend/tests/unit/rate_limit_middleware_test.py
+++ b/backend/tests/unit/rate_limit_middleware_test.py
@@ -49,6 +49,16 @@ def test_rate_limit_blocks_after_five_requests() -> None:
     assert resp.status_code == 429
 
 
+def test_rate_limit_uses_forwarded_header() -> None:
+    client = TestClient(create_app())
+    headers = {"X-Forwarded-For": "1.2.3.4"}
+    for _ in range(5):
+        resp = client.get("/foo", headers=headers)
+        assert resp.status_code == 200
+    resp = client.get("/foo", headers=headers)
+    assert resp.status_code == 429
+
+
 def test_root_not_rate_limited() -> None:
     client = TestClient(create_app())
     for _ in range(10):


### PR DESCRIPTION
## Summary
- use X-Forwarded-For, X-Real-IP or Forwarded headers in rate limiting middleware
- test rate limiting using a forwarded IP header

## Testing
- `poetry run pre-commit run --files ../backend/src/askpolis/rate_limiting.py ../backend/tests/unit/rate_limit_middleware_test.py`
- `poetry run mypy ../backend/src/askpolis/rate_limiting.py ../backend/tests/unit/rate_limit_middleware_test.py`
- `poetry run pytest -v -m unit ../backend/tests/unit`


------
https://chatgpt.com/codex/tasks/task_e_6887b4bba164832db724b482a963e6c9