### PR TITLE
Make rate limit configurable via env var

### DIFF
--- a/backend/compose.yaml
+++ b/backend/compose.yaml
@@ -13,6 +13,7 @@ services:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
       - OTEL_SERVICE_NAME=askpolis-api
       - OTEL_RESOURCE_ATTRIBUTES=environment=local
+      - RATE_LIMIT_REQUESTS_PER_MINUTE=10
     depends_on:
       - postgres
       - redis

--- a/backend/src/askpolis/rate_limiting.py
+++ b/backend/src/askpolis/rate_limiting.py
@@ -37,6 +37,14 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
             redis_client = cast(RedisLike, cast(Any, redis_asyncio).from_url(url))
         self.redis = redis_client
+        env_limit = os.getenv("RATE_LIMIT_REQUESTS_PER_MINUTE")
+        if env_limit:
+            try:
+                env_value = int(env_limit)
+                if env_value >= 1:
+                    limit = env_value
+            except ValueError:
+                pass
         self.limit = limit
         self.period = period
 

--- a/backend/tests/unit/rate_limit_middleware_test.py
+++ b/backend/tests/unit/rate_limit_middleware_test.py
@@ -1,3 +1,4 @@
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -74,3 +75,13 @@ def test_probes_not_rate_limited() -> None:
     for _ in range(10):
         resp = client.get("/readyz")
         assert resp.status_code == 200
+
+
+def test_env_var_overrides_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RATE_LIMIT_REQUESTS_PER_MINUTE", "2")
+    client = TestClient(create_app())
+    for _ in range(2):
+        resp = client.get("/foo")
+        assert resp.status_code == 200
+    resp = client.get("/foo")
+    assert resp.status_code == 429


### PR DESCRIPTION
## Summary
- read `RATE_LIMIT_REQUESTS_PER_MINUTE` in rate limiter
- default to 5 if not set or less than 1
- set the variable to 10 in the compose file
- test environment variable override of rate limit

## Testing
- `poetry run pre-commit run --files compose.yaml src/askpolis/rate_limiting.py tests/unit/rate_limit_middleware_test.py`
- `poetry run mypy .`
- `poetry run pytest -v -m unit`

------
https://chatgpt.com/codex/tasks/task_e_6888fc3d016c832db38c3a6764370b57