### PR TITLE
Add Docker dev mode with reload

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,6 +10,8 @@ ENV VIRTUAL_ENV=/app/.venv \
     PATH="/app/.venv/bin:$PATH"
 
 ENV HF_HOME=/app/models
+ENV ASKPOLIS_DEV=false
+ENV PYTHONPATH=/app/src
 
 FROM base AS builder
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,3 +1,15 @@
 # Backend
 
 Tha backend of AskPolis. It contains the main application: the API, analytical backend and scraping of the data.
+
+## Development with Docker
+
+The Dockerfile supports a development mode used by `compose.yaml`. When the
+environment variable `ASKPOLIS_DEV` is set to `true`, the container reloads the
+`src` folder on changes.
+
+Start the stack with:
+
+```bash
+docker compose up --build
+```

--- a/backend/compose.yaml
+++ b/backend/compose.yaml
@@ -13,6 +13,9 @@ services:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
       - OTEL_SERVICE_NAME=askpolis-api
       - OTEL_RESOURCE_ATTRIBUTES=environment=local
+      - ASKPOLIS_DEV=true
+    volumes:
+      - ./src:/app/src
     depends_on:
       - postgres
       - redis
@@ -30,6 +33,9 @@ services:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
       - OTEL_SERVICE_NAME=askpolis-worker
       - OTEL_RESOURCE_ATTRIBUTES=environment=local
+      - ASKPOLIS_DEV=true
+    volumes:
+      - ./src:/app/src
     depends_on:
       - postgres
       - redis
@@ -43,6 +49,9 @@ services:
     command: ./scripts/start-scheduler.sh
     environment:
       - CELERY_BROKER_URL=redis://redis:6379/0
+      - ASKPOLIS_DEV=true
+    volumes:
+      - ./src:/app/src
     depends_on:
       - worker
 

--- a/backend/src/scripts/start-api.sh
+++ b/backend/src/scripts/start-api.sh
@@ -11,12 +11,24 @@ export OTEL_RESOURCE_ATTRIBUTES="container.id=${container_id},${OTEL_RESOURCE_AT
 
 alembic upgrade head
 
-opentelemetry-instrument \
-    --traces_exporter otlp_proto_grpc \
-    --metrics_exporter otlp_proto_grpc \
-    --logs_exporter otlp_proto_grpc \
-    uvicorn askpolis.main:app \
-    --host 0.0.0.0 \
-    --port 8000 \
-    --no-access-log \
-    ${ASKPOLIS_DEV:+--reload --reload-dir /app/src}
+if [ "${ASKPOLIS_DEV:-false}" = "true" ]; then
+  opentelemetry-instrument \
+      --traces_exporter otlp_proto_grpc \
+      --metrics_exporter otlp_proto_grpc \
+      --logs_exporter otlp_proto_grpc \
+      uvicorn askpolis.main:app \
+      --host 0.0.0.0 \
+      --port 8000 \
+      --no-access-log \
+      --reload \
+      --reload-dir /app/src
+else
+  opentelemetry-instrument \
+      --traces_exporter otlp_proto_grpc \
+      --metrics_exporter otlp_proto_grpc \
+      --logs_exporter otlp_proto_grpc \
+      uvicorn askpolis.main:app \
+      --host 0.0.0.0 \
+      --port 8000 \
+      --no-access-log
+fi

--- a/backend/src/scripts/start-api.sh
+++ b/backend/src/scripts/start-api.sh
@@ -18,4 +18,5 @@ opentelemetry-instrument \
     uvicorn askpolis.main:app \
     --host 0.0.0.0 \
     --port 8000 \
-    --no-access-log
+    --no-access-log \
+    ${ASKPOLIS_DEV:+--reload --reload-dir /app/src}

--- a/backend/src/scripts/start-scheduler.sh
+++ b/backend/src/scripts/start-scheduler.sh
@@ -9,9 +9,19 @@ export OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true
 container_id=$(cat /proc/self/cgroup | grep docker | cut -d'/' -f3 | head -n 1)
 export OTEL_RESOURCE_ATTRIBUTES="container.id=${container_id},${OTEL_RESOURCE_ATTRIBUTES:-}"
 
-opentelemetry-instrument \
-    --traces_exporter otlp_proto_grpc \
-    --metrics_exporter otlp_proto_grpc \
-    --logs_exporter otlp_proto_grpc \
-    celery -A askpolis.celery:app beat \
-    --loglevel=info
+if [ "${ASKPOLIS_DEV:-false}" = "true" ]; then
+    watchfiles --filter python "\
+        opentelemetry-instrument \
+            --traces_exporter otlp_proto_grpc \
+            --metrics_exporter otlp_proto_grpc \
+            --logs_exporter otlp_proto_grpc \
+            celery -A askpolis.celery:app beat \
+            --loglevel=info" /app/src
+else
+    opentelemetry-instrument \
+        --traces_exporter otlp_proto_grpc \
+        --metrics_exporter otlp_proto_grpc \
+        --logs_exporter otlp_proto_grpc \
+        celery -A askpolis.celery:app beat \
+        --loglevel=info
+fi

--- a/backend/src/scripts/start-worker.sh
+++ b/backend/src/scripts/start-worker.sh
@@ -9,10 +9,21 @@ export OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true
 container_id=$(cat /proc/self/cgroup | grep docker | cut -d'/' -f3 | head -n 1)
 export OTEL_RESOURCE_ATTRIBUTES="container.id=${container_id},${OTEL_RESOURCE_ATTRIBUTES:-}"
 
-opentelemetry-instrument \
-    --traces_exporter otlp_proto_grpc \
-    --metrics_exporter otlp_proto_grpc \
-    --logs_exporter otlp_proto_grpc \
-    celery -A askpolis.celery:app worker \
-    --loglevel=info \
-    --concurrency=1
+if [ "${ASKPOLIS_DEV:-false}" = "true" ]; then
+    watchfiles --filter python "\
+        opentelemetry-instrument \
+            --traces_exporter otlp_proto_grpc \
+            --metrics_exporter otlp_proto_grpc \
+            --logs_exporter otlp_proto_grpc \
+            celery -A askpolis.celery:app worker \
+            --loglevel=info \
+            --concurrency=1" /app/src
+else
+    opentelemetry-instrument \
+        --traces_exporter otlp_proto_grpc \
+        --metrics_exporter otlp_proto_grpc \
+        --logs_exporter otlp_proto_grpc \
+        celery -A askpolis.celery:app worker \
+        --loglevel=info \
+        --concurrency=1
+fi


### PR DESCRIPTION
## Summary
- add `ASKPOLIS_DEV` and `PYTHONPATH` to Dockerfile
- enable hot reloading in start scripts when `ASKPOLIS_DEV=true`
- mount `src/` and set dev env var in compose file
- document dev usage in backend README

## Testing
- `poetry run pre-commit run --files Dockerfile README.md compose.yaml src/scripts/start-api.sh src/scripts/start-worker.sh src/scripts/start-scheduler.sh`
- `poetry run mypy .`
- `poetry run pytest -v -m unit`


------
https://chatgpt.com/codex/tasks/task_e_6888fd4d8064832dadb13f68e2f506de