### PR TITLE
chore(backend): run Python as non-root user

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -52,5 +52,9 @@ COPY --from=model ${HF_HOME} ${HF_HOME}
 
 WORKDIR /app
 
+RUN addgroup --system app && adduser --system --ingroup app app
+
 COPY src/ ./
-RUN chmod +x ./scripts/*.sh
+RUN chmod +x ./scripts/*.sh && chown -R app:app /app
+
+USER app


### PR DESCRIPTION
## Summary
- add dedicated system user in backend Dockerfile
- run Python processes as non-root user

## Testing
- `poetry run pre-commit run --files Dockerfile`
- `poetry run mypy .`
- `poetry run pytest -v -m unit`


------
https://chatgpt.com/codex/tasks/task_e_689067b1dabc832dbdaebe3e1109bbf3