### PR TITLE
fix: avoid N+1 queries when loading answers

### DIFF
--- a/backend/src/askpolis/qa/models.py
+++ b/backend/src/askpolis/qa/models.py
@@ -99,8 +99,8 @@ class Answer(Base):
     document_id: Mapped[Optional[uuid.UUID]] = mapped_column(
         DB_UUID(as_uuid=True), ForeignKey("documents.id", ondelete="CASCADE"), nullable=True
     )
-    contents: Mapped[list[AnswerContent]] = relationship("AnswerContent", cascade="all, delete-orphan")
-    citations: Mapped[list[Citation]] = relationship("Citation", cascade="all, delete-orphan")
+    contents: Mapped[list[AnswerContent]] = relationship("AnswerContent", cascade="all, delete-orphan", lazy="selectin")
+    citations: Mapped[list[Citation]] = relationship("Citation", cascade="all, delete-orphan", lazy="selectin")
     created_at = mapped_column(DateTime, nullable=False, default=lambda: datetime.datetime.now(datetime.UTC))
     updated_at = mapped_column(DateTime, nullable=False, default=lambda: datetime.datetime.now(datetime.UTC))
 

--- a/backend/tests/unit/qa/models_test.py
+++ b/backend/tests/unit/qa/models_test.py
@@ -1,0 +1,6 @@
+from askpolis.qa.models import Answer
+
+
+def test_answer_relationships_use_selectin() -> None:
+    assert Answer.contents.property.lazy == "selectin"
+    assert Answer.citations.property.lazy == "selectin"


### PR DESCRIPTION
## Summary
- eager load answer content and citations to cut down SQL queries
- test that answer relations use selectin loading

## Testing
- `poetry run pre-commit run --files src/askpolis/qa/models.py tests/unit/qa/models_test.py`
- `poetry run mypy .`
- `poetry run pytest -v -m unit`


------
https://chatgpt.com/codex/tasks/task_e_6890ee88530c832d8b827e6e812b5779