### PR TITLE
refactor(backend): cache embedding and reranker models

### DIFF
--- a/backend/src/askpolis/search/__init__.py
+++ b/backend/src/askpolis/search/__init__.py
@@ -2,7 +2,7 @@ from .dependencies import get_embeddings_repository, get_search_service
 from .embeddings_service import EmbeddingsService, get_embedding_model
 from .models import Embeddings, EmbeddingsCollection, SearchResponse, SearchResult
 from .repositories import EmbeddingsCollectionRepository, EmbeddingsRepository
-from .reranker_service import RerankerService
+from .reranker_service import RerankerService, get_reranker_service
 from .routes import router
 from .search_service import SearchService, SearchServiceBase
 
@@ -16,6 +16,7 @@ __all__ = [
     "get_embeddings_repository",
     "get_search_service",
     "RerankerService",
+    "get_reranker_service",
     "router",
     "SearchResponse",
     "SearchResult",

--- a/backend/src/askpolis/search/dependencies.py
+++ b/backend/src/askpolis/search/dependencies.py
@@ -8,7 +8,7 @@ from askpolis.db import get_db
 
 from .embeddings_service import EmbeddingsService, get_embedding_model
 from .repositories import EmbeddingsCollectionRepository, EmbeddingsRepository
-from .reranker_service import RerankerService
+from .reranker_service import get_reranker_service
 from .search_service import SearchService, SearchServiceBase
 
 
@@ -23,5 +23,5 @@ def get_search_service(
     document_repository = DocumentRepository(db)
     splitter = MarkdownSplitter(chunk_size=2000, chunk_overlap=400)
     embeddings_service = EmbeddingsService(document_repository, embeddings_repository, get_embedding_model(), splitter)
-    reranker_service = RerankerService()
+    reranker_service = get_reranker_service()
     return SearchService(EmbeddingsCollectionRepository(db), embeddings_service, reranker_service)

--- a/backend/src/askpolis/search/embeddings_service.py
+++ b/backend/src/askpolis/search/embeddings_service.py
@@ -1,5 +1,6 @@
 import os
 import uuid
+from functools import lru_cache
 from typing import Any, TypedDict, cast
 
 import numpy as np
@@ -85,6 +86,7 @@ class FakeModel:
         return result
 
 
+@lru_cache(maxsize=1)
 def get_embedding_model() -> FakeModel | M3Embedder:
     if os.getenv("DISABLE_INFERENCE") == "true":
         return FakeModel()

--- a/backend/src/askpolis/search/reranker_service.py
+++ b/backend/src/askpolis/search/reranker_service.py
@@ -1,4 +1,5 @@
 import os
+from functools import lru_cache
 
 from FlagEmbedding import FlagReranker
 
@@ -30,3 +31,8 @@ class RerankerService:
         logger.info("Reranking...")
         reranked_scores = self._reranker.compute_score([(query, doc.chunk) for doc in embeddings], normalize=True)
         return [(doc, float(score)) for score, doc in sorted(zip(reranked_scores, embeddings), reverse=True)][:limit]
+
+
+@lru_cache(maxsize=1)
+def get_reranker_service() -> RerankerService:
+    return RerankerService()

--- a/backend/tests/unit/search/model_singleton_test.py
+++ b/backend/tests/unit/search/model_singleton_test.py
@@ -1,0 +1,20 @@
+import pytest
+
+from askpolis.search.embeddings_service import get_embedding_model
+from askpolis.search.reranker_service import get_reranker_service
+
+
+def test_get_embedding_model_is_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DISABLE_INFERENCE", "true")
+    get_embedding_model.cache_clear()
+    model1 = get_embedding_model()
+    model2 = get_embedding_model()
+    assert model1 is model2
+
+
+def test_get_reranker_service_is_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DISABLE_INFERENCE", "true")
+    get_reranker_service.cache_clear()
+    service1 = get_reranker_service()
+    service2 = get_reranker_service()
+    assert service1 is service2


### PR DESCRIPTION
## Summary
- cache embedding model via `lru_cache` and expose single shared reranker service
- expose reranker service through search package and dependency wiring
- add tests to ensure embedding and reranker models are cached

## Testing
- `poetry run pre-commit run --files src/askpolis/search/embeddings_service.py src/askpolis/search/reranker_service.py src/askpolis/search/dependencies.py src/askpolis/search/__init__.py tests/unit/search/model_singleton_test.py`
- `poetry run mypy .`
- `poetry run pytest -v -m unit`


------
https://chatgpt.com/codex/tasks/task_e_68930e656630832da1b2d51367c9ae47