### PR TITLE
fix(backend): return serializable results from Celery tasks

### DIFF
--- a/backend/src/askpolis/data_fetcher/tasks.py
+++ b/backend/src/askpolis/data_fetcher/tasks.py
@@ -1,25 +1,30 @@
+from typing import Any
+
 from celery import shared_task
 
 from askpolis.data_fetcher import FetchedDataRepository
 from askpolis.data_fetcher.abgeordnetenwatch import AbgeordnetenwatchDataFetcher
 from askpolis.db import get_db
+from askpolis.task_utils import build_task_result
 
 
 @shared_task(name="fetch_bundestag_from_abgeordnetenwatch")
-def fetch_bundestag_from_abgeordnetenwatch() -> None:
+def fetch_bundestag_from_abgeordnetenwatch() -> dict[str, Any]:
     bundestag_id = 5
     session = next(get_db())
     try:
         data_fetcher = AbgeordnetenwatchDataFetcher(FetchedDataRepository(session))
         data_fetcher.fetch_election_programs(bundestag_id)
+        return build_task_result("success", str(bundestag_id), {"action": "fetch_election_programs"})
     finally:
         session.close()
 
 
 @shared_task(name="cleanup_outdated_data")
-def cleanup_outdated_data() -> None:
+def cleanup_outdated_data() -> dict[str, Any]:
     session = next(get_db())
     try:
         FetchedDataRepository(session).delete_outdated_data()
+        return build_task_result("success", None, {"action": "cleanup_outdated_data"})
     finally:
         session.close()

--- a/backend/src/askpolis/qa/tasks.py
+++ b/backend/src/askpolis/qa/tasks.py
@@ -1,10 +1,11 @@
 import uuid
-from typing import Optional
+from typing import Any
 
 from celery import shared_task
 
 from askpolis.db import get_db
 from askpolis.logging import get_logger
+from askpolis.task_utils import build_task_result
 
 from .models import Question
 from .repositories import QuestionRepository
@@ -13,27 +14,33 @@ logger = get_logger(__name__)
 
 
 @shared_task(name="answer_question_task")
-def answer_question_task(question_id: str) -> Optional[Question]:
+def answer_question_task(question_id: str) -> dict[str, Any]:
     from .dependencies import get_qa_service
 
     session = next(get_db())
     try:
         qid = uuid.UUID(question_id)
-        return get_qa_service(session).answer_question(qid)
+        question: Question | None = get_qa_service(session).answer_question(qid)
+        answers = [content.content for answer in question.answers for content in answer.contents] if question else []
+        status = "answered" if answers else "no_answer"
+        entity_id = str(question.id) if question else question_id
+        return build_task_result(status, entity_id, {"answers": answers})
     finally:
         session.close()
 
 
 @shared_task(name="answer_stale_questions_task")
-def answer_stale_questions_task() -> None:
+def answer_stale_questions_task() -> dict[str, Any]:
     session = next(get_db())
     try:
         question_repository = QuestionRepository(session)
         stale_questions = question_repository.get_stale_questions()
         logger.info(f"Scheduling {len(stale_questions)} stale questions...")
-        for question in stale_questions:
-            answer_question_task.delay(str(question.id))
+        scheduled = [str(question.id) for question in stale_questions]
+        for qid in scheduled:
+            answer_question_task.delay(qid)
         logger.info(f"Scheduled {len(stale_questions)} stale questions")
+        return build_task_result("scheduled", None, {"question_ids": scheduled})
     finally:
         session.close()
 

--- a/backend/src/askpolis/task_utils.py
+++ b/backend/src/askpolis/task_utils.py
@@ -1,0 +1,19 @@
+from typing import Any, Optional
+
+
+def build_task_result(
+    status: str,
+    entity_id: Optional[str] = None,
+    data: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    """Create a serializable task result for Celery tasks.
+
+    The returned dict can be displayed by Flower and contains the execution status,
+    the id of the processed entity and additional task specific data.
+    """
+    result: dict[str, Any] = {"status": status}
+    if entity_id is not None:
+        result["entity_id"] = entity_id
+    if data:
+        result["data"] = data
+    return result

--- a/backend/tests/unit/data_fetcher/tasks_test.py
+++ b/backend/tests/unit/data_fetcher/tasks_test.py
@@ -1,6 +1,7 @@
 """Tests for data_fetcher Celery tasks."""
 
-from typing import Any, Iterator
+from collections.abc import Iterator
+from typing import Any
 
 from askpolis.data_fetcher import tasks as df_tasks
 

--- a/backend/tests/unit/data_fetcher/tasks_test.py
+++ b/backend/tests/unit/data_fetcher/tasks_test.py
@@ -1,0 +1,49 @@
+"""Tests for data_fetcher Celery tasks."""
+
+from typing import Any, Iterator
+
+from askpolis.data_fetcher import tasks as df_tasks
+
+
+class DummySession:
+    def close(self) -> None:  # pragma: no cover - simple stub
+        pass
+
+
+def fake_get_db() -> Iterator[DummySession]:
+    yield DummySession()
+
+
+def test_fetch_bundestag_from_abgeordnetenwatch_returns_result(monkeypatch: Any) -> None:
+    class DummyDataFetcher:
+        def __init__(self, repo: Any) -> None:
+            pass
+
+        def fetch_election_programs(self, parliament_id: int) -> None:  # pragma: no cover - stub
+            pass
+
+    monkeypatch.setattr(df_tasks, "get_db", fake_get_db)
+    monkeypatch.setattr(df_tasks, "AbgeordnetenwatchDataFetcher", DummyDataFetcher)
+
+    result = df_tasks.fetch_bundestag_from_abgeordnetenwatch()
+
+    assert result["status"] == "success"
+    assert result["entity_id"] == "5"
+    assert result["data"]["action"] == "fetch_election_programs"
+
+
+def test_cleanup_outdated_data_returns_result(monkeypatch: Any) -> None:
+    class DummyRepository:
+        def __init__(self, session: DummySession) -> None:
+            pass
+
+        def delete_outdated_data(self) -> None:  # pragma: no cover - stub
+            pass
+
+    monkeypatch.setattr(df_tasks, "get_db", fake_get_db)
+    monkeypatch.setattr(df_tasks, "FetchedDataRepository", DummyRepository)
+
+    result = df_tasks.cleanup_outdated_data()
+
+    assert result["status"] == "success"
+    assert result["data"]["action"] == "cleanup_outdated_data"

--- a/backend/tests/unit/qa/tasks_test.py
+++ b/backend/tests/unit/qa/tasks_test.py
@@ -1,0 +1,81 @@
+"""Tests for QA Celery tasks."""
+
+import uuid
+from collections.abc import Iterator
+from typing import Any
+
+from askpolis.qa import dependencies as qa_dependencies
+from askpolis.qa import tasks as qa_tasks
+
+
+class DummyAnswerContent:
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+class DummyAnswer:
+    def __init__(self, contents: list[DummyAnswerContent]) -> None:
+        self.contents = contents
+
+
+class DummyQuestion:
+    def __init__(self, qid: uuid.UUID, answers: list[DummyAnswer]) -> None:
+        self.id = qid
+        self.answers = answers
+
+
+class DummyQAService:
+    def __init__(self, question: DummyQuestion) -> None:
+        self._question = question
+
+    def answer_question(self, qid: uuid.UUID) -> DummyQuestion:
+        assert qid == self._question.id
+        return self._question
+
+
+class DummySession:
+    def close(self) -> None:  # pragma: no cover - simple stub
+        pass
+
+
+def fake_get_db() -> Iterator[DummySession]:
+    yield DummySession()
+
+
+def test_answer_question_task_returns_result(monkeypatch: Any) -> None:
+    qid = uuid.uuid4()
+    question = DummyQuestion(qid, [DummyAnswer([DummyAnswerContent("hi")])])
+    monkeypatch.setattr(qa_tasks, "get_db", fake_get_db)
+    monkeypatch.setattr(qa_dependencies, "get_qa_service", lambda session: DummyQAService(question))
+
+    result = qa_tasks.answer_question_task(str(qid))
+
+    assert result["status"] == "answered"
+    assert result["entity_id"] == str(qid)
+    assert result["data"]["answers"] == ["hi"]
+
+
+def test_answer_stale_questions_task_returns_ids(monkeypatch: Any) -> None:
+    qids = [uuid.uuid4(), uuid.uuid4()]
+
+    class DummyQuestionRepository:
+        def __init__(self, session: DummySession) -> None:
+            pass
+
+        def get_stale_questions(self) -> list[DummyQuestion]:
+            return [DummyQuestion(qids[0], []), DummyQuestion(qids[1], [])]
+
+    scheduled: list[str] = []
+
+    def fake_delay(qid: str) -> None:  # pragma: no cover - simple stub
+        scheduled.append(qid)
+
+    monkeypatch.setattr(qa_tasks, "get_db", fake_get_db)
+    monkeypatch.setattr(qa_tasks, "QuestionRepository", DummyQuestionRepository)
+    monkeypatch.setattr(qa_tasks.answer_question_task, "delay", fake_delay)
+
+    result = qa_tasks.answer_stale_questions_task()
+
+    assert result["status"] == "scheduled"
+    assert result["data"]["question_ids"] == [str(q) for q in qids]
+    assert scheduled == [str(q) for q in qids]

--- a/backend/tests/unit/search/tasks_test.py
+++ b/backend/tests/unit/search/tasks_test.py
@@ -1,0 +1,105 @@
+"""Tests for search Celery tasks."""
+
+from typing import Any, Iterator
+
+from askpolis.core.models import Document, DocumentType
+from askpolis.search import tasks as search_tasks
+from askpolis.search.models import EmbeddingsCollection
+
+
+class DummySession:
+    def close(self) -> None:  # pragma: no cover - simple stub
+        pass
+
+
+def fake_get_db() -> Iterator[DummySession]:
+    yield DummySession()
+
+
+def test_test_embeddings_returns_result(monkeypatch: Any) -> None:
+    class DummyCollectionRepo:
+        def __init__(self, session: DummySession) -> None:
+            pass
+
+        def get_most_recent_by_name(self, name: str) -> EmbeddingsCollection:
+            return EmbeddingsCollection(name=name, version="v0", description="d")
+
+        def save(self, obj: Any) -> None:  # pragma: no cover - stub
+            pass
+
+    class DummyEmbeddingsRepo:
+        def __init__(self, session: DummySession) -> None:
+            pass
+
+    class DummyDocumentRepo:
+        def __init__(self, session: DummySession) -> None:
+            pass
+
+        def save(self, doc: Document) -> None:  # pragma: no cover - stub
+            pass
+
+        def add_pages(self, doc: Document, pages: Any) -> None:  # pragma: no cover - stub
+            pass
+
+    class DummyService:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        def embed_document(self, collection: EmbeddingsCollection, document: Document) -> list[int]:
+            return [1, 2, 3]
+
+    monkeypatch.setattr(search_tasks, "get_db", fake_get_db)
+    monkeypatch.setattr(search_tasks, "EmbeddingsCollectionRepository", DummyCollectionRepo)
+    monkeypatch.setattr(search_tasks, "EmbeddingsRepository", DummyEmbeddingsRepo)
+    monkeypatch.setattr(search_tasks, "DocumentRepository", DummyDocumentRepo)
+    monkeypatch.setattr(search_tasks, "EmbeddingsService", DummyService)
+    monkeypatch.setattr(search_tasks, "get_embedding_model", lambda: None)
+
+    result = search_tasks.test_embeddings()
+
+    assert result["status"] == "success"
+    assert "embeddings" in result["data"]
+    assert result["entity_id"] is not None
+
+
+def test_ingest_embeddings_for_one_document_returns_result(monkeypatch: Any) -> None:
+    class DummyCollectionRepo:
+        def __init__(self, session: DummySession) -> None:
+            pass
+
+        def get_most_recent_by_name(self, name: str) -> EmbeddingsCollection:
+            return EmbeddingsCollection(name=name, version="v0", description="d")
+
+        def save(self, obj: Any) -> None:  # pragma: no cover - stub
+            pass
+
+    class DummyEmbeddingsRepo:
+        def __init__(self, session: DummySession) -> None:
+            pass
+
+        def get_documents_without_embeddings(self) -> list[Document]:
+            return [Document("doc", DocumentType.ELECTION_PROGRAM)]
+
+    class DummyDocumentRepo:
+        def __init__(self, session: DummySession) -> None:
+            pass
+
+    class DummyService:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        def embed_document(self, collection: EmbeddingsCollection, document: Document) -> list[int]:
+            return [1, 2]
+
+    monkeypatch.setattr(search_tasks, "get_db", fake_get_db)
+    monkeypatch.setattr(search_tasks, "EmbeddingsCollectionRepository", DummyCollectionRepo)
+    monkeypatch.setattr(search_tasks, "EmbeddingsRepository", DummyEmbeddingsRepo)
+    monkeypatch.setattr(search_tasks, "DocumentRepository", DummyDocumentRepo)
+    monkeypatch.setattr(search_tasks, "EmbeddingsService", DummyService)
+    monkeypatch.setattr(search_tasks, "get_embedding_model", lambda: None)
+
+    result = search_tasks.ingest_embeddings_for_one_document()
+
+    assert result["status"] == "success"
+    assert "embeddings" in result["data"]
+    assert result["entity_id"] is not None

--- a/backend/tests/unit/search/tasks_test.py
+++ b/backend/tests/unit/search/tasks_test.py
@@ -1,6 +1,7 @@
 """Tests for search Celery tasks."""
 
-from typing import Any, Iterator
+from collections.abc import Iterator
+from typing import Any
 
 from askpolis.core.models import Document, DocumentType
 from askpolis.search import tasks as search_tasks


### PR DESCRIPTION
## Summary
- return structured result objects from Celery tasks for Flower
- add unit tests for Celery task results

## Testing
- `poetry run pre-commit run --files src/askpolis/task_utils.py src/askpolis/qa/tasks.py src/askpolis/data_fetcher/tasks.py src/askpolis/search/tasks.py tests/unit/qa/tasks_test.py tests/unit/data_fetcher/tasks_test.py tests/unit/search/tasks_test.py`
- `poetry run mypy .`
- `poetry run pytest -v -m unit`


------
https://chatgpt.com/codex/tasks/task_e_68930d8f912c832d93b1e8f5744d02e3