### PR TITLE
refactor(backend): use question repository in qa routes

### DIFF
--- a/backend/src/askpolis/qa/dependencies.py
+++ b/backend/src/askpolis/qa/dependencies.py
@@ -13,6 +13,12 @@ from .repositories import QuestionRepository
 from .tasks import CeleryQuestionScheduler
 
 
+def get_question_repository(
+    db: Annotated[Session, Depends(get_db)],
+) -> QuestionRepository:
+    return QuestionRepository(db)
+
+
 def get_qa_service(
     db: Annotated[Session, Depends(get_db)],
 ) -> QAService:

--- a/backend/src/askpolis/qa/routes.py
+++ b/backend/src/askpolis/qa/routes.py
@@ -8,18 +8,19 @@ from fastapi.responses import JSONResponse
 from askpolis.core import Document, DocumentRepository, get_document_repository
 from askpolis.search import Embeddings, EmbeddingsRepository, get_embeddings_repository
 
-from .dependencies import get_qa_service
+from .dependencies import get_qa_service, get_question_repository
 from .models import AnswerResponse, CitationResponse, CreateQuestionRequest, Question, QuestionResponse
 from .qa_service import QAService
+from .repositories import QuestionRepository
 
 router = APIRouter(prefix="/questions", responses={404: {"description": "Question not found"}}, tags=["questions"])
 
 
 def get_question_from_path(
     question_id: Annotated[uuid.UUID, Path()],
-    qa_service: Annotated[QAService, Depends(get_qa_service)],
+    question_repository: Annotated[QuestionRepository, Depends(get_question_repository)],
 ) -> Question:
-    question = qa_service.get_question(question_id)
+    question = question_repository.get(question_id)
     if question is None:
         raise HTTPException(status_code=404, detail="Question not found")
     return question

--- a/backend/tests/unit/qa/routes_test.py
+++ b/backend/tests/unit/qa/routes_test.py
@@ -5,16 +5,16 @@ from fastapi.testclient import TestClient
 
 from askpolis.core import get_document_repository
 from askpolis.main import app
-from askpolis.qa.dependencies import get_qa_service
+from askpolis.qa.dependencies import get_question_repository
 from askpolis.qa.models import Answer, AnswerContent, Question
 from askpolis.search import get_embeddings_repository
 
 
-class DummyQAService:
+class DummyQuestionRepository:
     def __init__(self, question: Question) -> None:
         self.question = question
 
-    def get_question(self, question_id: uuid.UUID) -> Question | None:
+    def get(self, question_id: uuid.UUID) -> Question | None:
         if question_id == self.question.id:
             return self.question
         return None
@@ -26,7 +26,7 @@ def test_get_question_returns_answer() -> None:
     answer.question_id = question.id
     question.answers.append(answer)
 
-    app.dependency_overrides[get_qa_service] = lambda: DummyQAService(question)
+    app.dependency_overrides[get_question_repository] = lambda: DummyQuestionRepository(question)
     app.dependency_overrides[get_document_repository] = lambda: MagicMock()
     app.dependency_overrides[get_embeddings_repository] = lambda: MagicMock()
 
@@ -46,7 +46,7 @@ def test_get_answer_trims_language_code() -> None:
     answer.question_id = question.id
     question.answers.append(answer)
 
-    app.dependency_overrides[get_qa_service] = lambda: DummyQAService(question)
+    app.dependency_overrides[get_question_repository] = lambda: DummyQuestionRepository(question)
     app.dependency_overrides[get_document_repository] = lambda: MagicMock()
     app.dependency_overrides[get_embeddings_repository] = lambda: MagicMock()
 


### PR DESCRIPTION
## Summary
- fetch questions from `QuestionRepository` in QA routes
- expose `get_question_repository` for dependency injection
- adjust QA route tests to override repository instead of service

## Testing
- `poetry run pre-commit run --files src/askpolis/qa/routes.py src/askpolis/qa/dependencies.py tests/unit/qa/routes_test.py`
- `poetry run mypy .`
- `poetry run pytest -v -m unit`


------
https://chatgpt.com/codex/tasks/task_e_689312a06b2c832d932212a82e0975bd