### PR TITLE
feat(backend): configure OpenTelemetry exporters

### DIFF
--- a/backend/src/askpolis/main.py
+++ b/backend/src/askpolis/main.py
@@ -6,6 +6,7 @@ from askpolis.logging import get_logger
 from askpolis.qa import router as qa_router
 from askpolis.rate_limiting import RateLimitMiddleware
 from askpolis.search import router as search_router
+from askpolis.telemetry import configure_otel
 
 logger = get_logger(__name__)
 logger.info("Starting AskPolis API...")
@@ -14,6 +15,7 @@ api_version = "v0"
 api_base_path = f"/{api_version}"
 
 app = FastAPI(docs_url="/")
+configure_otel(app)
 app.add_middleware(RateLimitMiddleware)
 app.include_router(core_router, prefix=api_base_path)
 app.include_router(qa_router, prefix=api_base_path)

--- a/backend/src/askpolis/telemetry.py
+++ b/backend/src/askpolis/telemetry.py
@@ -1,0 +1,23 @@
+from fastapi import FastAPI
+from opentelemetry import metrics, trace
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+
+def configure_otel(app: FastAPI) -> None:
+    resource = Resource.create({"service.name": "askpolis-api"})
+    trace_provider = TracerProvider(resource=resource)
+    trace_provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(insecure=True)))
+    trace.set_tracer_provider(trace_provider)
+
+    metric_reader = PeriodicExportingMetricReader(OTLPMetricExporter(insecure=True))
+    meter_provider = MeterProvider(resource=resource, metric_readers=[metric_reader])
+    metrics.set_meter_provider(meter_provider)
+
+    FastAPIInstrumentor().instrument_app(app)

--- a/backend/tests/unit/telemetry_test.py
+++ b/backend/tests/unit/telemetry_test.py
@@ -1,0 +1,10 @@
+from opentelemetry import metrics, trace
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.trace import TracerProvider
+
+from askpolis.main import app  # noqa: F401
+
+
+def test_telemetry_providers_configured() -> None:
+    assert isinstance(trace.get_tracer_provider(), TracerProvider)
+    assert isinstance(metrics.get_meter_provider(), MeterProvider)


### PR DESCRIPTION
## Summary
- configure OTLP exporters for traces and metrics in FastAPI
- initialize telemetry at app startup and add a regression test

## Testing
- `poetry run pre-commit run --files src/askpolis/telemetry.py src/askpolis/main.py tests/unit/telemetry_test.py`
- `poetry run mypy src/askpolis/main.py src/askpolis/telemetry.py tests/unit/telemetry_test.py` *(fails: interrupted)*
- `poetry run pytest -v -m unit`


------
https://chatgpt.com/codex/tasks/task_e_68b94f0d42a0832d87736bedcd962742